### PR TITLE
Refactor service log upload

### DIFF
--- a/cleantrashrooms-website/server.ts
+++ b/cleantrashrooms-website/server.ts
@@ -15,10 +15,22 @@ const storage = multer.diskStorage({
 
 const upload = multer({ storage });
 
-app.post('/api/upload', upload.single('file'), (req, res) => {
-  const filePath = `/uploads/${req.file?.originalname}`;
-  res.json({ path: filePath });
-});
+app.post(
+  '/api/upload',
+  upload.fields([
+    { name: 'beforePhoto', maxCount: 1 },
+    { name: 'afterPhoto', maxCount: 1 }
+  ]),
+  (req, res) => {
+    const files = req.files as Record<string, Express.Multer.File[]> | undefined;
+    const before = files?.beforePhoto?.[0];
+    const after = files?.afterPhoto?.[0];
+    res.json({
+      beforePhoto: before ? `/uploads/${before.originalname}` : '',
+      afterPhoto: after ? `/uploads/${after.originalname}` : ''
+    });
+  }
+);
 
 app.use('/uploads', express.static(uploadsDir));
 

--- a/cleantrashrooms-website/src/App.tsx
+++ b/cleantrashrooms-website/src/App.tsx
@@ -173,21 +173,19 @@ const api = {
     const beforeFile = formData.get('beforePhoto') as File | null;
     const afterFile = formData.get('afterPhoto') as File | null;
 
-    async function uploadFile(file: File | null): Promise<string> {
-      if (!file || file.size === 0) return '';
-      const fd = new FormData();
-      fd.append('file', file);
-      const res = await fetch(`${API_URL}/api/upload`, {
-        method: 'POST',
-        body: fd
-      });
-      if (!res.ok) throw new Error('Upload failed');
-      const data = await res.json();
-      return data.path as string;
-    }
+    const uploadData = new FormData();
+    if (beforeFile && beforeFile.size > 0) uploadData.append('beforePhoto', beforeFile);
+    if (afterFile && afterFile.size > 0) uploadData.append('afterPhoto', afterFile);
 
-    const beforePhoto = await uploadFile(beforeFile) || '/before-after-cleaning.jpg';
-    const afterPhoto = await uploadFile(afterFile) || '/clean-trash-room.jpg';
+    const uploadRes = await fetch(`${API_URL}/api/upload`, {
+      method: 'POST',
+      body: uploadData
+    });
+    if (!uploadRes.ok) throw new Error('Upload failed');
+    const uploaded = await uploadRes.json();
+
+    const beforePhoto = uploaded.beforePhoto || '/before-after-cleaning.jpg';
+    const afterPhoto = uploaded.afterPhoto || '/clean-trash-room.jpg';
     
     const now = new Date();
     const newServiceLog: ServiceLog = {


### PR DESCRIPTION
## Summary
- send both images in one form data POST to /api/upload
- update server to accept multiple fields and return both paths

## Testing
- `bun lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_686a93d1ca3083268f41e0bbd46ad125