### PR TITLE
Refactor createServiceLog and upload handler

### DIFF
--- a/cleantrashrooms-website/bun.lock
+++ b/cleantrashrooms-website/bun.lock
@@ -65,6 +65,8 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250620.0",
         "@eslint/js": "^9.25.0",
+        "@types/express": "^5.0.3",
+        "@types/multer": "^2.0.0",
         "@types/node": "^22.15.21",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
@@ -594,6 +596,10 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.20.7", "", { "dependencies": { "@babel/types": "^7.20.7" } }, "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng=="],
 
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
     "@types/d3-array": ["@types/d3-array@3.2.1", "", {}, "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="],
 
     "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
@@ -614,11 +620,25 @@
 
     "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
+    "@types/express": ["@types/express@5.0.3", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "*" } }, "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.0.6", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA=="],
+
     "@types/history": ["@types/history@4.7.11", "", {}, "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
+    "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
+
+    "@types/multer": ["@types/multer@2.0.0", "", { "dependencies": { "@types/express": "*" } }, "sha512-C3Z9v9Evij2yST3RSBktxP9STm6OdMc5uR1xF1SGr98uv8dUlAL2hqwrZ3GVB3uyMyiegnscEK6PGtYvNrjTjw=="],
+
     "@types/node": ["@types/node@22.15.21", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ=="],
+
+    "@types/qs": ["@types/qs@6.14.0", "", {}, "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
 
     "@types/react": ["@types/react@19.1.5", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-piErsCVVbpMMT2r7wbawdZsq4xMvIAhQuac2gedQHysu1TZYEigE6pnFfgZT+/jQnrRuF5r+SHzuehFjfRjr4g=="],
 
@@ -627,6 +647,10 @@
     "@types/react-router": ["@types/react-router@5.1.20", "", { "dependencies": { "@types/history": "^4.7.11", "@types/react": "*" } }, "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q=="],
 
     "@types/react-router-dom": ["@types/react-router-dom@5.3.3", "", { "dependencies": { "@types/history": "^4.7.11", "@types/react": "*", "@types/react-router": "*" } }, "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw=="],
+
+    "@types/send": ["@types/send@0.17.5", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w=="],
+
+    "@types/serve-static": ["@types/serve-static@1.15.8", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "*" } }, "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg=="],
 
     "@types/uuid": ["@types/uuid@9.0.8", "", {}, "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="],
 

--- a/cleantrashrooms-website/package.json
+++ b/cleantrashrooms-website/package.json
@@ -72,6 +72,8 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250620.0",
     "@eslint/js": "^9.25.0",
+    "@types/express": "^5.0.3",
+    "@types/multer": "^2.0.0",
     "@types/node": "^22.15.21",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",

--- a/cleantrashrooms-website/server.ts
+++ b/cleantrashrooms-website/server.ts
@@ -17,23 +17,34 @@ const storage = multer.diskStorage({
 
 const upload = multer({ storage });
 
-app.post('/api/upload', upload.single('file'), (req, res) => {
-  if (req.file) {
-    console.log(`Saved file: ${req.file.originalname} -> ${req.file.filename}`);
-  } else if (req.files) {
-    const before = Object.values(req.files).map(
-      (f) => (f as Express.Multer.File[])[0].originalname
-    );
-    const after = Object.values(req.files).map(
-      (f) => (f as Express.Multer.File[])[0].filename
-    );
-    console.log('Saved files:', before);
-    console.log('Renamed to:', after);
-  }
+app.post(
+  '/api/upload',
+  upload.fields([
+    { name: 'beforePhoto', maxCount: 1 },
+    { name: 'afterPhoto', maxCount: 1 }
+  ]),
+  (req, res) => {
+    const files = req.files as {
+      [fieldname: string]: Express.Multer.File[];
+    };
 
-  const filePath = `/uploads/${req.file?.filename ?? ''}`;
-  res.json({ path: filePath });
-});
+    const result: Record<string, string> = {};
+
+    if (files?.beforePhoto?.[0]) {
+      const f = files.beforePhoto[0];
+      console.log(`Saved file: ${f.originalname} -> ${f.filename}`);
+      result.beforePhoto = `/uploads/${f.filename}`;
+    }
+
+    if (files?.afterPhoto?.[0]) {
+      const f = files.afterPhoto[0];
+      console.log(`Saved file: ${f.originalname} -> ${f.filename}`);
+      result.afterPhoto = `/uploads/${f.filename}`;
+    }
+
+    res.json(result);
+  }
+);
 
 app.use('/uploads', express.static(uploadsDir));
 

--- a/cleantrashrooms-website/src/App.tsx
+++ b/cleantrashrooms-website/src/App.tsx
@@ -173,21 +173,24 @@ const api = {
     const beforeFile = formData.get('beforePhoto') as File | null;
     const afterFile = formData.get('afterPhoto') as File | null;
 
-    async function uploadFile(file: File | null): Promise<string> {
-      if (!file || file.size === 0) return '';
+    async function uploadFiles() {
+      if ((!beforeFile || beforeFile.size === 0) && (!afterFile || afterFile.size === 0)) {
+        return {} as Record<string, string>;
+      }
       const fd = new FormData();
-      fd.append('file', file);
+      if (beforeFile && beforeFile.size > 0) fd.append('beforePhoto', beforeFile);
+      if (afterFile && afterFile.size > 0) fd.append('afterPhoto', afterFile);
       const res = await fetch(`${API_URL}/api/upload`, {
         method: 'POST',
         body: fd
       });
       if (!res.ok) throw new Error('Upload failed');
-      const data = await res.json();
-      return data.path as string;
+      return (await res.json()) as Record<string, string>;
     }
 
-    const beforePhoto = await uploadFile(beforeFile) || '/before-after-cleaning.jpg';
-    const afterPhoto = await uploadFile(afterFile) || '/clean-trash-room.jpg';
+    const uploadRes = await uploadFiles();
+    const beforePhoto = uploadRes.beforePhoto || '/before-after-cleaning.jpg';
+    const afterPhoto = uploadRes.afterPhoto || '/clean-trash-room.jpg';
     
     const now = new Date();
     const newServiceLog: ServiceLog = {


### PR DESCRIPTION
## Summary
- allow uploading both before/after photos in one request
- send both files from createServiceLog using FormData
- track new types for Express and multer

## Testing
- `bun run lint`
- `bun run build`
- `./node_modules/.bin/tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686a97dd08088326af4c274368d0383c