### PR TITLE
Fix service log photo URLs

### DIFF
--- a/cleantrashrooms-website/src/App.tsx
+++ b/cleantrashrooms-website/src/App.tsx
@@ -189,8 +189,12 @@ const api = {
     }
 
     const uploadRes = await uploadFiles();
-    const beforePhoto = uploadRes.beforePhoto || '/before-after-cleaning.jpg';
-    const afterPhoto = uploadRes.afterPhoto || '/clean-trash-room.jpg';
+    const beforePhoto = uploadRes.beforePhoto
+      ? `${API_URL}${uploadRes.beforePhoto}`
+      : '/before-after-cleaning.jpg';
+    const afterPhoto = uploadRes.afterPhoto
+      ? `${API_URL}${uploadRes.afterPhoto}`
+      : '/clean-trash-room.jpg';
     
     const now = new Date();
     const newServiceLog: ServiceLog = {


### PR DESCRIPTION
## Summary
- use API_URL to build full image URLs in `createServiceLog`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a9a743d508326a75e38490419f39c